### PR TITLE
Fix typo in comment in example config file

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -63,7 +63,7 @@ module.exports = {
     // 'redis' or 'memory'
     adapter: 'redis',
     redis: {
-      // If url is supplied port and url will be ignored
+      // If url is supplied, port and host will be ignored
       url: 'redis://user:pass@host:port',
       port: 6379,
       host: 'localhost',


### PR DESCRIPTION
Just another typo fix (in the comments (of an example config file)). 

Those are the only things I can conceive fixing, the whole rest is just awesome =]