### PR TITLE
Whitelist profile in user model

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -115,7 +115,8 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
       'username',
       'email',
       'password',
-      'confirmPassword'
+      'confirmPassword',
+      'profile'
     ],
     customValidators: {
       validateEmail: self.validateEmail,


### PR DESCRIPTION
As in the [`README.md`](), the `profile` will be returned if it exists. But it can't be created by default (unless one creates an specific route just to update an already created user).

I just added the `'profile'` string to the UserModel whitelist so that it can be added to the `superlogin.register` params (on the client).