### PR TITLE
Return promises for all Mocha unit tests.  Added test config file to support non-admin party testing + more.

### DIFF
--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -20,21 +20,24 @@ describe('Cloudant', function() {
     })
   }); */
 
-  it('should create the test DB', function(done) {
-    previous.then(function() {
+  before(function() {
+    return previous.then(function() {
       testDB = new PouchDB(cloudantUrl + '/temp_test');
       return testDB;
-    }).then(function() {
-      done();
-    })
-      .catch(function(err) {
-        done(err);
-      });
+    });
   });
 
-  it('should generate an API key', function(done) {
+  after(function() {
     this.timeout(5000);
-    previous
+    return previous.finally(function() {
+      // return testDB.destroy();
+      return BPromise.resolve();
+    });
+  });
+
+  it('should generate an API key', function() {
+    this.timeout(5000);
+    return previous
       .then(function() {
         return cloudant.getAPIKey(testDB);
       })
@@ -42,16 +45,12 @@ describe('Cloudant', function() {
         expect(result.ok).to.equal(true);
         expect(result.key).to.be.a('string');
         apiKey = result.key;
-        done();
-      })
-      .catch(function(err) {
-        done(err);
       });
   });
 
-  it('should authorize keys', function(done) {
+  it('should authorize keys', function() {
     this.timeout(10000);
-    previous
+    return previous
       .then(function() {
         return cloudant.authorizeKeys('test_user', testDB, ['abc123', 'def456']);
       })
@@ -61,16 +60,12 @@ describe('Cloudant', function() {
       .then(function(secDoc) {
         expect(secDoc.cloudant.abc123[0]).to.equal('user:test_user');
         expect(secDoc.cloudant.abc123[1]).to.equal('_reader');
-        done();
-      })
-      .catch(function(err) {
-        done(err);
       });
   });
 
-  it('should deauthorize a key', function(done) {
+  it('should deauthorize a key', function() {
     this.timeout(10000);
-    previous
+    return previous
       .then(function() {
         return cloudant.deauthorizeKeys(testDB, 'abc123');
       })
@@ -80,24 +75,6 @@ describe('Cloudant', function() {
       .then(function(secDoc) {
         expect(secDoc.cloudant.abc123).to.be.an('undefined');
         expect(secDoc.cloudant.def456[1]).to.equal('_reader');
-        done();
-      })
-      .catch(function(err) {
-        done(err);
-      });
-  });
-
-  it('should clean up the test db', function(done) {
-    this.timeout(5000);
-    previous.finally(function() {
-      // return testDB.destroy();
-      return BPromise.resolve();
-    })
-      .then(function() {
-        done();
-      })
-      .catch(function(err) {
-        done(err);
       });
   });
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,11 @@
+module.exports = {
+  getDBUrl: function (config) {
+    var host;
+    if (config.user)
+      host = encodeURIComponent(config.user) + ':' + encodeURIComponent(config.password) + '@' + config.host;
+    else
+      host = config.host;
+
+    return config.protocol + host;
+  }
+};

--- a/test/mailer.spec.js
+++ b/test/mailer.spec.js
@@ -38,7 +38,7 @@ var theUser = {
 var mailer = new Mailer(mailerTestConfig);
 
 describe('Mailer', function() {
-  it('should send a confirmation email', function(done) {
+  it('should send a confirmation email', function() {
     return mailer.sendEmail('confirmEmail', 'super@example.com', {req: req, user: theUser})
       .then(function(result) {
         var response = result.response.toString();
@@ -47,10 +47,6 @@ describe('Mailer', function() {
         expect(response.search('Subject: Please confirm your email')).to.be.greaterThan(-1);
         expect(response.search('Hi Super,')).to.be.greaterThan(-1);
         expect(response.search('https://example.com/auth/confirm-email/abc123')).to.be.greaterThan(-1);
-        done();
-      })
-      .catch(function(err) {
-        done(err);
       });
   });
 

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -11,7 +11,7 @@ function start(config) {
   var app = express();
 
   // all environments
-  app.set('port', process.env.PORT || config.port ||  4000);
+  app.set('port', process.env.PORT || config.port ||  5000);
   app.use(morgan('dev'));
   app.use(bodyParser.json());
 

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -1,14 +1,15 @@
 module.exports = {
+  port: 5000,
   testMode: {
     noEmail: true,
     oauthDebug: true
   },
   dbServer: {
-    protocol: 'http://',
-    host: 'localhost:5984',
-    user: '',
-    password: '',
-    userDB: 'sl_test-users',
+    protocol: process.env.COUCH_PROTOCOL || 'http://',
+    host:     process.env.COUCH_HOST     || 'localhost:5984',
+    user:     process.env.COUCH_USER     || '',
+    password: process.env.COUCH_PASS     || '',
+    userDB:      'sl_test-users',
     couchAuthDB: 'sl_test-keys'
   },
   security: {


### PR DESCRIPTION
I've complied with your wish to rebase and merge all these separate commits together (was a 5 hour ordeal today 2nd attempt fighting the git patch system - not fun!). Sadly the 1st patch was not mine so now they are collapsed it looks like I'm not the author as it just picked up the author of the 1st commit. Merge process would only use the 1st commit title so this won't document what happened in your log. Sorry I have no control over this. 

All the commits needed to be applied in sequence to pass the unit tests hence submitting them as separate PRs was not feasible. I had intentionally left them separated so you could understand what each change was doing but now they are merged I' not so sure you can.

* Return promises for all Mocha unit tests (replacing done() and catch()) - biggest change.
* Added test config file to support non-admin party testing for Couch and env vars for dbServer. 
* Configure to use port 5000 (4000 conflicts for me and another dev). 
- user.spec.js: database setup/teardown it() tests are now in before()/after() rather than separate unit tests so tests can be run separately.
* Use unvalidated email for password reset if validated email not set (this one crept in as part of the 1st patch from ybain). Its a good fix but really should have been a separate commit. I only noticed it on final code review.