### PR TITLE
Manage access to userDBs by .config file

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -14,6 +14,23 @@ module.exports = function(data, defaults) {
     return result;
   };
 
+  var _signatures = [];
+
+  this.refreshSignature = function(key)
+  {
+    var item = this.getItem(key);
+    _signatures[key] = util.hashObjectOrVariable(item);
+    return _signatures[key];
+  };
+
+  this.getSignature = function(key)
+  {
+    if(!_signatures[key])
+      return this.refreshSignature(key);
+    return _signatures[key];
+  };
+
+
   this.setItem = function(key, value) {
     return util.setObjectRef(this.config, key, value);
   };

--- a/lib/dbauth/index.js
+++ b/lib/dbauth/index.js
@@ -55,16 +55,10 @@ module.exports = function (config, userDB, couchAuthDB) {
     adminRoles = adminRoles || [];
     memberRoles = memberRoles || [];
     // Create and the database and seed it if a designDoc is specified
-    var prefix = config.getItem('userDBs.privatePrefix') ? config.getItem('userDBs.privatePrefix') + '_' : '';
     var finalDBName, newDB;
     // Make sure we have a legal database name
-    var username = userDoc._id;
-    username = getLegalDBName(username);
-    if(type === 'shared') {
-      finalDBName = dbName;
-    } else {
-      finalDBName = prefix + dbName + '$' + username;
-    }
+    var prefix = config.getItem('userDBs.privatePrefix') ? config.getItem('userDBs.privatePrefix') + '_' : '';
+    finalDBName = util.getFinalDBName(prefix, dbName, type, userDoc);
     return self.createDB(finalDBName)
       .then(function() {
         newDB = new PouchDB(util.getDBURL(config.getItem('dbServer')) + '/' + finalDBName);
@@ -98,6 +92,9 @@ module.exports = function (config, userDB, couchAuthDB) {
       })
       .then(function() {
         return BPromise.resolve(finalDBName);
+      })
+      .catch(function(err){
+        throw err;
       });
   };
 
@@ -242,7 +239,7 @@ module.exports = function (config, userDB, couchAuthDB) {
         if(err.status === 412) {
           return BPromise.resolve(false);
         } else {
-          return BPromise.reject(err.text);
+          return BPromise.reject(err.cause.response.text);
         }
       });
   };
@@ -255,24 +252,3 @@ module.exports = function (config, userDB, couchAuthDB) {
 
   return this;
 };
-
-// Escapes any characters that are illegal in a CouchDB database name using percent codes inside parenthesis
-// Example: 'My.name@example.com' => 'my(2e)name(40)example(2e)com'
-function getLegalDBName(input) {
-  input = input.toLowerCase();
-  var output = encodeURIComponent(input);
-  output = output.replace(/\./g, '%2E');
-  output = output.replace(/!/g, '%21');
-  output = output.replace(/~/g, '%7E');
-  output = output.replace(/\*/g, '%2A');
-  output = output.replace(/'/g, '%27');
-  output = output.replace(/\(/g, '%28');
-  output = output.replace(/\)/g, '%29');
-  output = output.replace(/\-/g, '%2D');
-  output = output.toLowerCase();
-  output = output.replace(/(%..)/g, function(esc) {
-    esc = esc.substr(1);
-    return '(' + esc + ')';
-  });
-  return output;
-}

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,7 @@ module.exports = function (configData, passport, userDB, couchAuthDB) {
     logoutSession: user.logoutSession,
     logoutOthers: user.logoutOthers,
     removeUser: user.remove,
-    confirmSession: user.confirmToken,
+    confirmSession: user.confirmSession,
     removeExpiredKeys: user.removeExpiredKeys,
     sendEmail: mailer.sendEmail,
     quitRedis: user.quitRedis,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -45,21 +45,24 @@ module.exports = function(config, router, passport, user) {
 
   router.post('/logout',
     function (req, res, next) {
-      var sessionToken = util.getSessionToken(req);
-      if(!sessionToken) {
-        return next({
-          error: 'unauthorized',
-          status: 401
-        });
-      }
-      user.logoutSession(sessionToken)
+      util.getSessionTokenPromise(req, user)
+      .then(function(sessionToken)
+      {
+        user.logoutSession(sessionToken)
         .then(function () {
           res.status(200).json({ok: true, success: 'Logged out'});
         }, function (err) {
           console.error('Logout failed');
           return next(err);
         });
-    });
+      })
+      .catch(function(err){
+        return next({
+          error: 'unauthorized',
+          status: 401
+        });
+      });
+  });
 
   router.post('/logout-others',
     passport.authenticate('bearer', {session: false}),

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -78,20 +78,24 @@ module.exports = function(config, router, passport, user) {
 
   router.post('/logout-all',
     function (req, res, next) {
-      var sessionToken = util.getSessionToken(req);
-      if(!sessionToken) {
-        return next({
-          error: 'unauthorized',
-          status: 401
-        });
-      }
-      user.logoutUser(null, sessionToken)
+      //
+      util.getSessionTokenPromise(req, user)
+      .then(function(sessionToken)
+      {
+        user.logoutUser(null, sessionToken)
         .then(function () {
           res.status(200).json({success: 'Logged out'});
         }, function (err) {
           console.error('Logout-all failed');
           return next(err);
         });
+      })
+      .catch(function(err){
+        return next({
+          error: 'unauthorized',
+          status: 401
+        });
+      });
     });
 
   // Setting up the auth api

--- a/lib/user.js
+++ b/lib/user.js
@@ -572,8 +572,9 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
     if(!userAccess || !(userAccess instanceof Array))
       userAccess = config.getItem('security.defaultUserAccess');
 
+    var defaultRequireUserAccess = config.getItem('userDBs.model._default.requireUserAccess');
     for (var db_key in user.personalDBs) {
-      var requireUserAccess = config.getItem('userDBs.model.' + personalDBs[db_key].name + '.requireUserAccess') || config.getItem('userDBs.model._default.requireUserAccess');
+      var requireUserAccess = config.getItem('userDBs.model.' + personalDBs[db_key].name + '.requireUserAccess') || defaultRequireUserAccess;
       if(requireUserAccess instanceof Array && requireUserAccess.length > 0) {
         if(!userAccess || !(userAccess instanceof Array) || userAccess.length <= 0)
           continue;
@@ -590,6 +591,79 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
     return BPromise.resolve(allowedDBs);
   };
 
+  this.checkPersonalDBsDiff = function(user, deletePrivate, deleteShared)
+  {
+    if(!config.getItem('session.checkUserDBsDiffFromDefault'))
+      return BPromise.resolve(user);
+
+    var promises = [];
+
+    var processUserDBs = function(defaultDBsList, type) {
+      Object.keys(user.personalDBs).forEach(function(userDBName){
+        var prefix = config.getItem('userDBs.privatePrefix') ? config.getItem('userDBs.privatePrefix') + '_' : '';
+        var defaultDBName = util.castFinalToDefaultDBName(prefix, userDBName, type, user);
+        var index_defaultDBName = defaultDBsList.indexOf(defaultDBName);
+        if(index_defaultDBName < 0)
+        {
+          //If the userDBName isn't in the defaultDBsList, it has to be removed
+          promises.push(
+            self.removeUserDB(user._id, userDBName, deletePrivate, deleteShared)
+            .then(function() {
+              delete user.personalDBs[userDBName];
+          }));
+        }
+        else
+        {
+          //It's already in, so remove it from the defaultDBsList, so the database won't be re-created
+          defaultDBsList.splice(index_defaultDBName, 1);
+        }
+      });
+    };
+
+    var finalPrivateDBsToAdd = null;
+    if (user.privateDBsSignature !== config.getSignature("userDBs.defaultDBs.private"))
+    {
+      var privateDBsToAdd = config.getItem("userDBs.defaultDBs.private");
+      // Just in case defaultDBs is not specified
+      if(Array.isArray(privateDBsToAdd) && privateDBsToAdd.length > 0) {
+        finalPrivateDBsToAdd = extend(true, [], privateDBsToAdd);
+        processUserDBs(finalPrivateDBsToAdd, 'private');
+      }
+    }
+
+    var finalSharedDBsToAdd = null;
+    if (user.sharedDBsSignature !== config.getSignature("userDBs.defaultDBs.shared"))
+    {
+      var sharedDBsToAdd = config.getItem("userDBs.defaultDBs.shared");
+      // Just in case defaultDBs is not specified
+      if(Array.isArray(sharedDBsToAdd) && sharedDBsToAdd.length > 0) {
+        finalSharedDBsToAdd = extend(true, [], sharedDBsToAdd);
+        processUserDBs(finalSharedDBsToAdd, 'shared');
+      }
+    }
+
+    if( (Array.isArray(finalPrivateDBsToAdd) && finalPrivateDBsToAdd.length > 0) || (Array.isArray(finalSharedDBsToAdd) && finalSharedDBsToAdd.length > 0))
+    {
+
+      return BPromise.all(promises)
+      .then(function() {
+        return addUserDBs(user, finalPrivateDBsToAdd, finalSharedDBsToAdd);
+      })
+      .then(function(newUser){
+        user = newUser;
+        return userDB.put(user);
+      })
+      .then(function(newUser){
+        return userDB.get(newUser.id);
+      });
+    }
+    else
+    {
+        return BPromise.resolve(user);
+    }
+  };
+
+
   this.createSession = function(user_id, provider, req) {
     var user;
     var newToken;
@@ -601,6 +675,10 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
     return userDB.get(user_id)
       .then(function(record) {
         user = record;
+        return self.checkPersonalDBsDiff(user, false, false); //Do not delete completely the removed DBs
+      })
+      .then(function(user_){
+        user = user_;
         return self.getAllowedBDs(user);
       })
       .then(function(nAllowedDBs)
@@ -1282,7 +1360,8 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
       });
   }
 
-  function addUserDBs(newUser) {
+  //Add all the default DBs to a user, you can pass specific private and shared DBs names. Else the fuction is going to use the config's names (userDBs.defaultDBs)
+  function addUserDBs(newUser, privateDBs, sharedDBs) {
     // Add personal DBs
     if(!config.getItem('userDBs.defaultDBs')) {
       return BPromise.resolve(newUser);
@@ -1308,22 +1387,23 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
     };
 
     // Just in case defaultDBs is not specified
-    var defaultPrivateDBs = config.getItem('userDBs.defaultDBs.private');
+    var defaultPrivateDBs = privateDBs || config.getItem('userDBs.defaultDBs.private');
     if(!Array.isArray(defaultPrivateDBs)) {
       defaultPrivateDBs = [];
     }
     processUserDBs(defaultPrivateDBs, 'private');
-    var defaultSharedDBs = config.getItem('userDBs.defaultDBs.shared');
+    var defaultSharedDBs = sharedDBs || config.getItem('userDBs.defaultDBs.shared');
     if(!Array.isArray(defaultSharedDBs)) {
       defaultSharedDBs = [];
     }
     processUserDBs(defaultSharedDBs, 'shared');
 
     return BPromise.all(promises).then(function() {
+      newUser.privateDBsSignature = config.getSignature('userDBs.defaultDBs.private');
+      newUser.sharedDBsSignature = config.getSignature('userDBs.defaultDBs.shared');
       return BPromise.resolve(newUser);
     });
   }
 
   return this;
-
 };

--- a/lib/user.js
+++ b/lib/user.js
@@ -565,16 +565,47 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
       });
   };
 
+  this.getAllowedBDs = function(user) {
+    var personalDBs = user.personalDBs;
+    var allowedDBs = {};
+    var userAccess = user.access;
+    if(!userAccess || !(userAccess instanceof Array))
+      userAccess = config.getItem('security.defaultUserAccess');
+
+    for (var db_key in user.personalDBs) {
+      var requireUserAccess = config.getItem('userDBs.model.' + personalDBs[db_key].name + '.requireUserAccess') || config.getItem('userDBs.model._default.requireUserAccess');
+      if(requireUserAccess instanceof Array && requireUserAccess.length > 0) {
+        if(!userAccess || !(userAccess instanceof Array) || userAccess.length <= 0)
+          continue;
+        for( var i_a = 0; i_a < requireUserAccess.length; ++i_a)
+        {
+          if(userAccess.indexOf(requireUserAccess[i_a]) >= 0)
+            allowedDBs[db_key] = personalDBs[db_key];
+        }
+      }
+      else {
+        allowedDBs[db_key] = personalDBs[db_key];
+      }
+    }
+    return BPromise.resolve(allowedDBs);
+  };
+
   this.createSession = function(user_id, provider, req) {
     var user;
     var newToken;
     var newSession;
     var password;
+    var allowedDBs = {};
     req = req || {};
     var ip = req.ip;
     return userDB.get(user_id)
       .then(function(record) {
         user = record;
+        return self.getAllowedBDs(user);
+      })
+      .then(function(nAllowedDBs)
+      {
+        allowedDBs = nAllowedDBs;
         return generateSession(user._id, user.roles);
       })
       .then(function(token) {
@@ -588,10 +619,10 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
       })
       .then(function() {
         // authorize the new session across all dbs
-        if(!user.personalDBs) {
+        if(!user.personalDBs || !allowedDBs || Object.keys(allowedDBs).length <= 0) {
           return BPromise.resolve();
         }
-        return dbAuth.authorizeUserSessions(user_id, user.personalDBs, newToken.key, user.roles);
+        return dbAuth.authorizeUserSessions(user_id, allowedDBs, newToken.key, user.roles);
       })
       .then(function() {
         if(!user.session) {
@@ -637,7 +668,7 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
             publicURL = config.getItem('dbServer.protocol') + newSession.token + ':' + newSession.password + '@' +
               config.getItem('dbServer.host') + '/';
           }
-          Object.keys(user.personalDBs).forEach(function(finalDBName) {
+          Object.keys(allowedDBs).forEach(function(finalDBName) {
             userDBs[user.personalDBs[finalDBName].name] = publicURL + finalDBName;
           });
           newSession.userDBs = userDBs;

--- a/lib/util.js
+++ b/lib/util.js
@@ -130,11 +130,11 @@ exports.getSessionTokenPromise = function(req, user)
       })
       .catch(function(err){
         return reject(null);
-      })
+      });
     }
     return reject(null);
   });
-}
+};
 
 // Generates views for each registered provider in the user design doc
 exports.addProvidersToDesignDoc = function(config, ddoc) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,7 @@ var BPromise = require('bluebird');
 var URLSafeBase64 = require('urlsafe-base64');
 var uuid = require('node-uuid');
 var pwd = require('couch-pwd');
+var crypto = require('crypto');
 
 exports.URLSafeUUID = function() {
   return URLSafeBase64.encode(uuid.v4(null, new Buffer(16)));
@@ -250,4 +251,103 @@ exports.arrayUnion = function (a, b) {
     }
   }
   return result;
+};
+
+
+/**
+ * Hash object to md5
+ *
+ * @param {array} an array / object
+* @param {string} crypto's hash method (md5, sha1, ...)
+ * @return {string} resulting hash
+ */
+function hashObject(object, hashMethod) {
+  var cHashMethod = hashMethod || "md5";
+  var hash = crypto.createHash(cHashMethod)
+    .update(JSON.stringify(object, function (k, v) {
+      if (k[0] === "_") return undefined; // remove api stuff
+      else if (typeof v === "function") // consider functions
+        return v.toString();
+      else return v;
+    }))
+    .digest('hex');
+  return hash;
+}
+
+exports.hashObject = hashObject;
+
+/**
+* Automaticaly detect if it has to hash an object or a variable (string, int, ...) to md5
+*
+* @param {all} the item to hash (Array, Object, Int, String)
+* @param {string} crypto's hash method (md5, sha1, ...)
+* @return {string} resulting hash
+*/
+exports.hashObjectOrVariable = function(item, hashMethod)
+{
+  if(!item)
+  {
+    return null;
+  }
+  var cHashMethod = hashMethod || "md5";
+  if(typeof item === "object" || item instanceof Array)
+  {
+    return hashObject(item, cHashMethod);
+  }
+  else
+  {
+    return crypto.createHash(cHashMethod).update(item).digest('hex');
+  }
+};
+
+// Escapes any characters that are illegal in a CouchDB database name using percent codes inside parenthesis
+// Example: 'My.name@example.com' => 'my(2e)name(40)example(2e)com'
+function getLegalDBName(input) {
+  input = input.toLowerCase();
+  var output = encodeURIComponent(input);
+  output = output.replace(/\./g, '%2E');
+  output = output.replace(/!/g, '%21');
+  output = output.replace(/~/g, '%7E');
+  output = output.replace(/\*/g, '%2A');
+  output = output.replace(/'/g, '%27');
+  output = output.replace(/\(/g, '%28');
+  output = output.replace(/\)/g, '%29');
+  output = output.replace(/\-/g, '%2D');
+  output = output.toLowerCase();
+  output = output.replace(/(%..)/g, function(esc) {
+    esc = esc.substr(1);
+    return '(' + esc + ')';
+  });
+  return output;
+}
+
+exports.getLegalDBName = getLegalDBName;
+
+exports.getFinalDBName = function(prefix, dbName, type, userDoc)
+{
+
+  var finalDBName;
+  // Make sure we have a legal database name
+  var username = userDoc._id;
+  username = getLegalDBName(username);
+  if(type === 'shared') {
+    return dbName;
+  } else {
+    finalDBName = prefix + dbName + '$' + username;
+  }
+  return finalDBName;
+};
+
+exports.castFinalToDefaultDBName = function(prefix, finalDBName, type, userDoc)
+{
+  var defaultDBName;
+
+  var username = userDoc._id;
+  username = getLegalDBName(username);
+  if(type === 'shared') {
+    return finalDBName;
+  } else {
+    defaultDBName = finalDBName.replace(prefix,"").replace('$' + username, "");
+  }
+  return defaultDBName;
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -105,6 +105,37 @@ exports.getSessionToken = function(req) {
   }
 };
 
+exports.getSessionTokenPromise = function(req, user)
+{
+  return new BPromise(function (resolve, reject) {
+    if (req.headers && req.headers.authorization) {
+      var parts = req.headers.authorization.split(' ');
+      if (parts.length == 2) {
+        var scheme = parts[0];
+        var credentials = parts[1];
+        if (/^Bearer$/i.test(scheme)) {
+          var parse = credentials.split(':');
+          if(parse.length < 2) {
+            reject(null);
+          }
+          return resolve(parse[0]);
+        }
+      }
+    }
+    else if (req.body && req.body.token && req.body.password)
+    {
+      return user.confirmSession(req.body.token, req.body.password)
+      .then(function(){
+          return resolve(req.body.token);
+      })
+      .catch(function(err){
+        return reject(null);
+      })
+    }
+    return reject(null);
+  });
+}
+
 // Generates views for each registered provider in the user design doc
 exports.addProvidersToDesignDoc = function(config, ddoc) {
   var providers = config.getItem('providers');

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "couch-pwd": "0.0.1",
+    "crypto": "0.0.3",
     "ejs": "^2.3.1",
     "express": "^4.13.3",
     "extend": "^3.0.0",


### PR DESCRIPTION
Allow to indicate in the .config if a model requireUserAccess. 

Why would you want that ?

Imagine that you create an App, and you want to only allow some user (Premium account) to access to the server to sync (like evernote), else it's only in the local pouchDB database.

Well, you say in the _default model requireUserAccess : ["sync"]. And you update the user's data to give him

access like that : user.access = ["sync"].

So, you'll still have access to the user's profile, with a session etc, but they won't have access to their other databases, and they'll be force to use pouchDB locally ;). 

I give an exemple in test/user.spec.js