### PR TITLE
Issue #67: forgotPassword() should secure hash the stored reset token.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,6 +58,7 @@ module.exports = function (configData, passport, userDB, couchAuthDB) {
   var superlogin = {
     config: config,
     router: router,
+    mailer: mailer,
     passport: passport,
     userDB: userDB,
     couchAuthDB: couchAuthDB,

--- a/lib/user.js
+++ b/lib/user.js
@@ -757,7 +757,8 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
     var user;
     return passwordResetForm.validate()
       .then(function () {
-        return userDB.query('auth/passwordReset', {key: form.token, include_docs: true});
+        var tokenHash = util.hashToken(form.token);
+        return userDB.query('auth/passwordReset', {key: tokenHash, include_docs: true});
       }, function(err) {
         return BPromise.reject({
           error: 'Validation failed',
@@ -881,7 +882,7 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
 
   this.forgotPassword = function(email, req) {
     req = req || {};
-    var user, hash;
+    var user, token, tokenHash;
     return userDB.query('auth/email', {key: email, include_docs: true})
       .then(function(result) {
         if(!result.rows.length) {
@@ -891,9 +892,10 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
           });
         }
         user = result.rows[0].doc;
-        hash = util.URLSafeUUID();
+        token = util.URLSafeUUID();
+        tokenHash = util.hashToken(token);
         user.forgotPassword = {
-          token: hash,
+          token: tokenHash, // Store secure hashed token
           issued: Date.now(),
           expires: Date.now() + tokenLife * 1000
         };
@@ -904,7 +906,7 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
       })
       .then(function() {
         return mailer.sendEmail('forgotPassword', user.email || user.unverifiedEmail.email,
-          {user: user, req: req, token: user.forgotPassword.token});
+          {user: user, req: req, token: token}); // Send user the unhashed token
       }).then(function() {
         emitter.emit('forgot-password', user);
         return BPromise.resolve(user.forgotPassword);

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,9 +4,14 @@ var BPromise = require('bluebird');
 var URLSafeBase64 = require('urlsafe-base64');
 var uuid = require('node-uuid');
 var pwd = require('couch-pwd');
+var crypto = require('crypto');
 
 exports.URLSafeUUID = function() {
   return URLSafeBase64.encode(uuid.v4(null, new Buffer(16)));
+};
+
+exports.hashToken = function(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
 };
 
 exports.hashPassword = function (password) {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "jshint-stylish": "^2.1.0",
     "mocha": "^2.4.5",
     "morgan": "^1.5.2",
-    "rimraf": "^2.5.2"
+    "rimraf": "^2.5.2",
+    "sinon": "^1.17.4",
+    "sinon-chai": "^2.8.0"
   }
 }


### PR DESCRIPTION
I finally found that I needed to add `sinon` and `sinon-chai` to add a `spy()` on `Mailer.sendEmail()`.  My MockMailer worked in user.spec.js but not test.spec so in the end I just used a spy for both test suites.

