### PR TITLE
Fixed mail template since tokenLife is set to 24h (86400) by default

### DIFF
--- a/templates/email/forgot-password.ejs
+++ b/templates/email/forgot-password.ejs
@@ -5,5 +5,5 @@ If you made this request, please click on the link below or paste this into your
 
 <%= req.headers['x-forwarded-proto'] || req.protocol %>://<%= req.headers.host %>/password-reset/<%= token %>
 
-This link will work for 1 hour or until your password is reset.
+This link will work for 24 hours or until your password is reset.
 If you did not ask to change your password, please ignore this email and your account will remain unchanged.


### PR DESCRIPTION
Just to remove confusion, since `tokenLife` is set to 24 hours (86400  seconds).