### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,7 +2,7 @@
 
 var BPromise = require('bluebird');
 var URLSafeBase64 = require('urlsafe-base64');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var pwd = require('couch-pwd');
 var crypto = require('crypto');
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "express": "^4.13.3",
     "extend": "^3.0.0",
     "fs-extra": "^0.30.0",
-    "node-uuid": "^1.4.3",
     "nodemailer": "^2.3.0",
     "nodemailer-stub-transport": "^1.0.0",
     "passport": "^0.3.2",
@@ -50,7 +49,8 @@
     "redis": "^2.5.2",
     "sofa-model": "^0.2.0",
     "superagent": "^1.2.0",
-    "urlsafe-base64": "1.0.0"
+    "urlsafe-base64": "1.0.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "body-parser": "^1.9.2",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.