### PR TITLE
Assign pre-bound removeExpiredKeys

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -1193,7 +1193,7 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
       });
   };
 
-  this.removeExpiredKeys = dbAuth.removeExpiredKeys;
+  this.removeExpiredKeys = dbAuth.removeExpiredKeys.bind(dbAuth);
 
   this.confirmSession = function(key, password) {
     return session.confirmToken(key, password);


### PR DESCRIPTION
The `user.removeExpiredKeys` method must be assigned to the bound version of `dbAuth.removeExpiredKeys` method to correctly preserve the `this` inside the latter. Otherwise, it receives `user` object as its `this` context and throws on `self.removeKeys` call which is a non-existent method in `user`.