### PR TITLE
avoid doc.unverifiedEmail is undefined errors in couchdb log

### DIFF
--- a/designDocs/user-design.js
+++ b/designDocs/user-design.js
@@ -4,7 +4,7 @@ module.exports = {
       email: function(doc) {
         if(doc.email) {
           emit(doc.email, null);
-        } else if(doc.unverifiedEmail.email) {
+        } else if(doc.unverifiedEmail && doc.unverifiedEmail.email) {
           emit(doc.unverifiedEmail.email, null);
         }
       },
@@ -20,7 +20,7 @@ module.exports = {
         emit(doc._id, null);
         if(doc.email) {
           emit(doc.email, null);
-        } else if(doc.unverifiedEmail.email) {
+        } else if(doc.unverifiedEmail && doc.unverifiedEmail.email) {
           emit(doc.unverifiedEmail.email, null);
         }
       },


### PR DESCRIPTION
We found a lot of messages like this in our coucdb log: 
`OS Process #Port<0.5512> Log :: function raised exception (new TypeError("doc.unverifiedEmail is undefined", "undefined", 5)) with doc._id <USERNAME>`

They disapper when this fix is applied.