### PR TITLE
fixed syntax in the config example

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -45,7 +45,7 @@ module.exports = {
     usernameField: 'user',
     passwordField: 'pass',
     // Override default constraints
-    passwordConstraints = {
+    passwordConstraints: {
       length: {
         minimum: 6,
         message: "must be at least 6 characters"


### PR DESCRIPTION
there was an '=' instead of an ':'