### PR TITLE
pkdbf2 digest error with node >= 8.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/colinskow/superlogin",
   "dependencies": {
     "bluebird": "^3.3.4",
-    "couch-pwd": "0.0.1",
+    "couch-pwd": "github:zeMirco/couch-pwd",
     "ejs": "^2.3.1",
     "express": "^4.13.3",
     "extend": "^3.0.0",


### PR DESCRIPTION
updating couch-pwd from ver 0.0.1 to zeMirco/couch-pwd
solves the issue with pkdbf2 digest on more recent versions of node.
 Changes to be committed:
	modified:   package.json