### PR TITLE
update pouchdb (prebuilt binaries)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "passport": "^0.3.2",
     "passport-http-bearer-sl": "^1.0.1",
     "passport-local": "^1.0.0",
-    "pouchdb": "~5.3.1",
+    "pouchdb": "~6.3.4",
     "pouchdb-seed-design": "^0.2.0",
     "redis": "^2.5.2",
     "sofa-model": "^0.2.0",


### PR DESCRIPTION
Hi!

Latest version of `pouchdb` is `6.3.4` and the next version will contain an updated version of `leveldown` which has prebuilt binaries for most systems. Which makes it more easily installed on windows etc. I'm guessing next version of `pouchdb` will be `6.3.5` so it should be enough to use `~6.3.4` to get the future fix automatically.

Cheers