### PR TITLE
Allow unlinking of last provider if user has a password

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -533,8 +533,8 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
             status: 400
           });
         }
-        // We can only unlink if there are at least two providers
-        if(!user.providers || !(user.providers instanceof Array) || user.providers.length < 2) {
+        // We can only unlink if there are at least two providers, or if they have a password separately set up
+        if(!user.derived_key && (!user.providers || !(user.providers instanceof Array) || user.providers.length < 2)) {
           return BPromise.reject({
             error: 'Unlink failed',
             message: 'You can\'t unlink your only provider!',


### PR DESCRIPTION
Currently you can signup with username/password, link a social provider later, but then cannot unlink it once you have.

This should account for users who use a password, but then want to unlink their last provider.