### PR TITLE
Issue 119

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -41,6 +41,9 @@ module.exports = {
     confirmEmailRedirectURL: '/',
     // Set this to true to disable usernames and use emails instead
     emailUsername: false,
+    // If this is more then zero a random ID of that length will be used in place of the username. This number must
+    // be even and must be big enough to allow it to be unique. I would suggest at least 16.
+    randomUIDLength: 0,
     // Custom names for the username and password fields in your sign-in form
     usernameField: 'user',
     passwordField: 'pass',

--- a/lib/user.js
+++ b/lib/user.js
@@ -29,6 +29,8 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
 
   var emailUsername = config.getItem('local.emailUsername');
 
+  var randomUsername = config.getItem('local.randomUsername');
+
 
   this.validateUsername = function (username) {
     if (!username) {
@@ -263,6 +265,9 @@ module.exports = function (config, userDB, couchAuthDB, mailer, emitter) {
         newUser = result;
         if(emailUsername) {
           newUser._id = newUser.email;
+        }
+        if(typeof(randomUsername) === 'number') {
+          newUser._id = require("crypto").randomBytes(Math.floor(randomUsername/2)).toString('hex');
         }
         if(config.getItem('local.sendConfirmEmail')) {
           newUser.unverifiedEmail = {


### PR DESCRIPTION
As per https://github.com/colinskow/superlogin/issues/119

This is a small patch which allows the system to generate random user _id values. These values are then propagated across the name of the user's private database. I think this allows for a more sensible way to externally reference user records from other documents and decouples the username or email address from the internal representation of the user and their data.