### PR TITLE
Fixes issue 64

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -3,7 +3,7 @@
 var BPromise = require('bluebird');
 var URLSafeBase64 = require('urlsafe-base64');
 var uuid = require('uuid');
-var pwd = require('couch-pwd');
+var pwd = require('couch-pwd-updated');
 var crypto = require('crypto');
 
 exports.URLSafeUUID = function() {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/colinskow/superlogin",
   "dependencies": {
     "bluebird": "^3.3.4",
-    "couch-pwd": "github:zeMirco/couch-pwd",
+    "couch-pwd-updated": "^1.0.0",
     "ejs": "^2.3.1",
     "express": "^4.13.3",
     "extend": "^3.0.0",


### PR DESCRIPTION
Small patch which fixes [issue 64](https://github.com/colinskow/superlogin/issues/64) by using versioned version of `couch-pwd-updated` instead of pointing directly to master of `couch-pwd.`